### PR TITLE
Add 2-card rule to card OCR

### DIFF
--- a/card_2_debug_ocr.py
+++ b/card_2_debug_ocr.py
@@ -59,8 +59,10 @@ def main():
 
             hand = [c for c in [c1, c2] if c]
 
-            # === Phantom suppression
-            if len(hand) == 1 and hand[0] in ['A', '10', '7']:
+            # === Discard incomplete reads
+            if len(hand) < 2:
+                # Optional debug output for skipped hands
+                # print(f"Skipping 1-card hand: {hand}")
                 continue
 
             # === Handle delayed hand clear


### PR DESCRIPTION
## Summary
- discard OCR results that contain fewer than 2 cards
- remove prior phantom card suppression logic

## Testing
- `python -m py_compile card_2_debug_ocr.py`
- `python -m py_compile auto_blackjack_counter.py blackjack_counter.py card_1_debug_ocr.py`


------
https://chatgpt.com/codex/tasks/task_e_687a8aaa4bec832c89aeb75a6144af35