### PR TITLE
Remove phantom card checks

### DIFF
--- a/auto_blackjack_counter.py
+++ b/auto_blackjack_counter.py
@@ -99,7 +99,7 @@ def main():
                 text = pytesseract.image_to_string(gray, config='--psm 6')
                 cleaned = clean_text(text)
                 cards = extract_cards(cleaned)
-                if not cards:
+                if len(cards) < 2:
                     continue
 
                 # === Require 2x match to confirm
@@ -113,10 +113,6 @@ def main():
                     continue
 
                 prev_cards = last_cards[label]
-
-                # === Suppression rules for lone A/10/7 in player zones
-                if label != "Dealer Hand" and len(cards) == 1 and cards[0] in ['A', '10', '7']:
-                    continue
 
                 if cards == prev_cards:
                     continue


### PR DESCRIPTION
## Summary
- drop obsolete phantom card suppression logic
- skip OCR results with fewer than two cards

## Testing
- `python -m py_compile auto_blackjack_counter.py blackjack_counter.py card_1_debug_ocr.py card_2_debug_ocr.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687a8bb5773c832cb705308c6c52a4fa