### PR TITLE
Fix skip logic for zero-card hands

### DIFF
--- a/card_2_debug_ocr.py
+++ b/card_2_debug_ocr.py
@@ -60,10 +60,10 @@ def main():
             hand = [c for c in [c1, c2] if c]
 
             # === Discard incomplete reads
-            if len(hand) < 2:
+            if len(hand) == 1:
                 # Optional debug output for skipped hands
                 # print(f"Skipping 1-card hand: {hand}")
-                continue
+                continue  # skip phantom or incomplete hand
 
             # === Handle delayed hand clear
             if not hand:


### PR DESCRIPTION
## Summary
- allow 0-card hands so the clear logic can trigger
- continue skipping 1-card phantom hands

## Testing
- `python -m py_compile card_2_debug_ocr.py`

------
https://chatgpt.com/codex/tasks/task_e_687a8d13cc94832ca513ceffe77f5fe1