### PR TITLE
Add OCR support for third card

### DIFF
--- a/card_2_debug_ocr.py
+++ b/card_2_debug_ocr.py
@@ -10,6 +10,7 @@ pytesseract.pytesseract.tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tessera
 # === CARD ZONES ===
 card_1_region = (1825, 940, 1872, 985)
 card_2_region = (1867, 946, 1907, 976)
+card_3_region = (1908, 946, 1933, 976)
 
 def grab_gray(region):
     img = np.array(ImageGrab.grab(bbox=region))
@@ -51,17 +52,21 @@ def main():
             now = time.time()
             gray1 = grab_gray(card_1_region)
             gray2 = grab_gray(card_2_region)
+            gray3 = grab_gray(card_3_region)
 
             _, thresh1 = cv2.threshold(gray1, 160, 255, cv2.THRESH_BINARY)
             _, thresh2 = cv2.threshold(gray2, 160, 255, cv2.THRESH_BINARY)
+            _, thresh3 = cv2.threshold(gray3, 160, 255, cv2.THRESH_BINARY)
 
             raw1 = pytesseract.image_to_string(thresh1, config='--psm 6')
             raw2 = pytesseract.image_to_string(thresh2, config='--psm 6')
+            raw3 = pytesseract.image_to_string(thresh3, config='--psm 6')
 
             c1 = extract_card(clean_text(raw1))
             c2 = extract_card(clean_text(raw2))
+            c3 = extract_card(clean_text(raw3))
 
-            hand = [c for c in [c1, c2] if c]
+            hand = [c for c in [c1, c2, c3] if c]
 
             # === Discard incomplete reads
             if len(hand) == 1:
@@ -125,7 +130,7 @@ def main():
                 else:
                     should_print = False
             if should_print:
-                print(f"🂠 Card 1: {c1}, Card 2: {c2} → ✅ Hand: {hand}")
+                print(f"🂠 Card 1: {c1}, Card 2: {c2}, Card 3: {c3} → ✅ Hand: {hand}")
                 last_hand = hand.copy()
                 hand_was_cleared = False
 


### PR DESCRIPTION
## Summary
- enable OCR for a third card by defining `card_3_region`
- capture and process `card_3` in the main OCR loop
- extend hand construction to include card 3 and show it in debug output

## Testing
- `python -m py_compile card_2_debug_ocr.py`

------
https://chatgpt.com/codex/tasks/task_e_687a95fe8f24832c84aacb47a10ed18e