### PR TITLE
Fix inferred blackjack hand counting

### DIFF
--- a/card_2_debug_ocr.py
+++ b/card_2_debug_ocr.py
@@ -99,8 +99,9 @@ def main():
             if bj_counter == "21" and len(hand) == 1:
                 hand = ['A', '10']
                 print("♠ Blackjack inferred from counter → Hand: ['A', '10']")
+                last_hand = hand.copy()
                 last_cleaned = hand.copy()
-                hand_confirm_count = 2  # force it to pass confirmation filter
+                hand_confirm_count = 2  # force confirmation bypass
 
             # === Discard incomplete reads
             if len(hand) == 1:


### PR DESCRIPTION
## Summary
- ensure an inferred blackjack hand is confirmed

## Testing
- `pytest -q`
- `flake8` *(fails: E501, E302, F841)*

------
https://chatgpt.com/codex/tasks/task_e_687aaecdc370832cae6f1c9fa6179d3f