### PR TITLE
Fix phantom bust card counting

### DIFF
--- a/card_2_debug_ocr.py
+++ b/card_2_debug_ocr.py
@@ -146,11 +146,25 @@ def main():
                         hand_total = sum(get_card_total_value(c) for c in hand_to_count)
 
                         if bj_total is not None and 22 <= bj_total <= 26 and bj_total - hand_total >= 2:
+                            # Remove the previously added raw hand delta before applying phantom card logic
                             running_count -= delta
                             phantom_card_value = bj_total - hand_total
-                            running_count += phantom_card_value
+
+                            # Map the difference to a likely card rank
+                            if phantom_card_value == 10:
+                                phantom_card = '10'
+                            elif phantom_card_value == 11:
+                                phantom_card = 'A'
+                            elif 2 <= phantom_card_value <= 6:
+                                phantom_card = str(phantom_card_value)
+                            else:
+                                phantom_card = '10'
+
+                            phantom_hi_lo_value = get_card_value(phantom_card)
+
+                            running_count += phantom_hi_lo_value
                             print(
-                                f"⚠️ Bust mismatch detected: Hand value = {hand_total}, Counter = {bj_total} → Phantom +{phantom_card_value} inserted"
+                                f"⚠️ Bust mismatch detected: Hand value = {hand_total}, Counter = {bj_total} → Phantom {phantom_card} added (Hi-Lo: {phantom_hi_lo_value:+})"
                             )
 
                     print("🧼 Hand cleared after 5s blank.")


### PR DESCRIPTION
## Summary
- fix phantom bust card calculation to use hi-lo mapping

## Testing
- `python -m py_compile card_2_debug_ocr.py`
- `python -m py_compile blackjack_counter.py auto_blackjack_counter.py card_1_debug_ocr.py card_2_debug_ocr.py`


------
https://chatgpt.com/codex/tasks/task_e_687ab3bbcf50832cacc8627bf2dfa4e4