### PR TITLE
Fix phantom detection when bj_total missing

### DIFF
--- a/card_2_debug_ocr.py
+++ b/card_2_debug_ocr.py
@@ -179,7 +179,13 @@ def main():
                         except ValueError:
                             bj_total = None
 
+
                         hand_total = get_hand_total(hand_to_count)
+
+                        # ✅ Bust inference when bj_total is unreadable
+                        if bj_total is None and hand_total >= 22:
+                            print(f"🛡️ Inferring bust due to hand_total = {hand_total} (bj_total OCR failed)")
+                            bj_total = hand_total  # force phantom correction path
 
                         if bj_total is None and last_bj_total and 22 <= last_bj_total <= 26:
                             bj_total = last_bj_total


### PR DESCRIPTION
## Summary
- infer a bust when `bj_total` is unreadable and `hand_total` is high

## Testing
- `python -m py_compile card_2_debug_ocr.py`

------
https://chatgpt.com/codex/tasks/task_e_687b13fe1ff8832c9bd19c0c6fc23ee9