### PR TITLE
Add 5th card detection for Blackjack OCR

### DIFF
--- a/card_2_debug_ocr.py
+++ b/card_2_debug_ocr.py
@@ -12,6 +12,7 @@ card_1_region = (1825, 940, 1872, 985)
 card_2_region = (1867, 946, 1907, 976)
 card_3_region = (1908, 946, 1933, 976)
 card_4_region = (1950, 946, 1973, 976)
+card_5_region = (1826, 964, 1853, 996)
 double_card_region = (1948, 985, 1983, 1013)
 bj_counter_region = (1975, 875, 2016, 905)
 
@@ -103,18 +104,21 @@ def main():
             gray2 = grab_gray(card_2_region)
             gray3 = grab_gray(card_3_region)
             gray4 = grab_gray(card_4_region)
+            gray5 = grab_gray(card_5_region)
             bj_gray = grab_gray(bj_counter_region)
 
             _, thresh1 = cv2.threshold(gray1, 160, 255, cv2.THRESH_BINARY)
             _, thresh2 = cv2.threshold(gray2, 160, 255, cv2.THRESH_BINARY)
             _, thresh3 = cv2.threshold(gray3, 160, 255, cv2.THRESH_BINARY)
             _, thresh4 = cv2.threshold(gray4, 160, 255, cv2.THRESH_BINARY)
+            _, thresh5 = cv2.threshold(gray5, 160, 255, cv2.THRESH_BINARY)
             _, bj_thresh = cv2.threshold(bj_gray, 160, 255, cv2.THRESH_BINARY)
 
             raw1 = pytesseract.image_to_string(thresh1, config='--psm 6')
             raw2 = pytesseract.image_to_string(thresh2, config='--psm 6')
             raw3 = pytesseract.image_to_string(thresh3, config='--psm 6')
             raw4 = pytesseract.image_to_string(thresh4, config='--psm 6')
+            raw5 = pytesseract.image_to_string(thresh5, config='--psm 6')
             # === Double-Down Card Support ===
             double_gray = grab_gray(double_card_region)
             rotated = cv2.rotate(double_gray, cv2.ROTATE_90_CLOCKWISE)
@@ -125,12 +129,13 @@ def main():
             c2 = extract_card(clean_text(raw2))
             regular_c3 = extract_card(clean_text(raw3))
             c4 = extract_card(clean_text(raw4))
+            c5 = extract_card(clean_text(raw5))
             double_card = extract_card(clean_text(raw_double))
             bj_counter = clean_digits(bj_raw)
 
             third_card = double_card if double_card else regular_c3
 
-            cards = [c1, c2, third_card, c4]
+            cards = [c1, c2, third_card, c4, c5]
             hand = [c for c in cards if c]
 
             if len(hand) >= 2:
@@ -267,7 +272,7 @@ def main():
                 else:
                     should_print = False
             if should_print:
-                print(f"🂠 Card 1: {c1}, Card 2: {c2}, Card 3: {third_card}, Card 4: {c4} → ✅ Hand: {hand}")
+                print(f"🂠 Card 1: {c1}, Card 2: {c2}, Card 3: {third_card}, Card 4: {c4}, Card 5: {c5} → ✅ Hand: {hand}")
                 last_hand = hand.copy()
                 hand_was_cleared = False
 


### PR DESCRIPTION
## Summary
- add `card_5_region` for optional 5th card
- read the 5th card in the OCR loop and include it in the hand display

## Testing
- `python3 -m py_compile card_2_debug_ocr.py`

------
https://chatgpt.com/codex/tasks/task_e_687b1990ed04832ca195540d0979f4a0